### PR TITLE
provide instructions for getting kubernetes client generator if it doesn't exist

### DIFF
--- a/genapi.sh
+++ b/genapi.sh
@@ -4,6 +4,14 @@ set -ex
 sed 's/com.github.tilt-dev.tilt.pkg.apis.core.//g' src/gen/swagger.json.original > src/gen/swagger.json.unprocessed
 
 # Run the Kubernetes codegen
+genpath="../gen"
+if [ ! -d "$genpath" ]; then
+  echo "Kubernetes client generator not found at $genpath"
+  echo "In the directory above this one, run:"
+  echo "\tgit clone https://github.com/kubernetes-client/gen.git"
+  exit 1
+fi
+
 ../gen/openapi/typescript.sh src/gen settings
 
 # Make all the imports consistent with how our typescript/nextjs config


### PR DESCRIPTION
idk if ../gen is the best place for this library to live long-term, that path should probably be configurable etc., but this will at least make the client generation experience slightly easier for the next person to pull this